### PR TITLE
Allow specifying cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Welcome to **quick VLLM**, a slim Python wrapper that makes talking to a
 
 ## Features
 
-| Feature                           | Description                                                                                         |
+| Feature                           | Description |
 | --------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **Turn-key**                      | Automatically waits for the vLLM server to boot before sending the first request.                   |
+| **Turn-key**                      | Automatically waits for the vLLM server to boot before sending the first request. |
 | **Cache**                         | Generated text is cached on disk; re-running the same call with the same settings is instantaneous. |
-| **Batching**                      | Built-in multiprocessing lets you hit high throughput with a single function call.                  |
-| **Metrics**                       | BLEU score utilities out of the box.                                                                |
-| **Configurable**                  | Control cache behaviour and port with CLI flags or environment variables.                           |
+| **Batching**                      | Built-in multiprocessing lets you hit high throughput with a single function call. |
+| **Metrics**                       | BLEU score utilities out of the box. |
+| **Configurable**                  | Control cache behaviour and port with CLI flags or environment variables. |
 | **Multi-host support (NEW)**      | The new `VLLMClient` class lets you spin up *multiple* clients, each with its own host/port, in one script. |
 
 ---
@@ -88,17 +88,19 @@ print(east.send(batch, just_return_text=True))        # multiprocess batching st
 ```
 
 Both the functional helpers and the class share the *same* cache directory, so
-you can mix and match freely.
+you can mix and match freely. Pass `cache_dir="/path/to/cache"` to override the
+default location.
 
 ---
 
 ## Settings quick-reference
 
-| Flag / env var         | Effect                                                        |
+| Flag / env var         | Effect |
 | ---------------------- | ------------------------------------------------------------- |
-| `--port 8000`          | Point *functional* helpers (`send`, …) at a different port.   |
+| `--port 8000`          | Point *functional* helpers (`send`, …) at a different port. |
 | `--force_cache_miss 1` | Ignore cached generations *and* overwrite with fresh results. |
-| `--disable_cache 1`    | Bypass cache entirely (no load, no save).                     |
+| `--disable_cache 1`    | Bypass cache entirely (no load, no save). |
+| `cache_dir=/path`      | Write cache files to this directory. |
 
 > **Note**
 > For `VLLMClient` objects just pass `port` / `host` to the constructor. The

--- a/quick_vllm/_config.py
+++ b/quick_vllm/_config.py
@@ -1,13 +1,25 @@
 import os
 
-def get_TMP_DIR():
-	"""
-	Creates a temporary directory for storing files.
-	"""
-		
-	filepath_to_this_file = os.path.abspath(__file__)
-	TMP_DIR = os.path.join(os.path.dirname(filepath_to_this_file), "tmp")
-	os.makedirs(TMP_DIR, exist_ok=True)
-	return TMP_DIR
+def get_TMP_DIR() -> str:
+    """Return the default cache directory inside the package install path."""
+
+    filepath_to_this_file = os.path.abspath(__file__)
+    tmp_dir = os.path.join(os.path.dirname(filepath_to_this_file), "tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+    return tmp_dir
+
+
+def set_TMP_DIR(path: str) -> str:
+    """Override the cache directory used by :mod:`quick_vllm`.
+
+    The directory is created if it does not already exist and the new path is
+    returned for convenience.
+    """
+
+    global TMP_DIR
+    TMP_DIR = os.path.abspath(path)
+    os.makedirs(TMP_DIR, exist_ok=True)
+    return TMP_DIR
+
 
 TMP_DIR = get_TMP_DIR()

--- a/quick_vllm/cache.py
+++ b/quick_vllm/cache.py
@@ -19,273 +19,263 @@ import traceback
 
 
 
-def safe_clear_key(key):
-	if isinstance(key, str):
-		try:
-			os.remove(quick_path_gen(key), )
-		except:
-			return False
-		return True
-	else:
-		ret_vals = []
-		for k in key:
-			ret_vals.append(safe_clear_key(k))
-		return ret_vals
+def safe_clear_key(key, cache_dir: str | None = None):
+        if isinstance(key, str):
+                try:
+                        os.remove(quick_path_gen(key, cache_dir=cache_dir))
+                except Exception:
+                        return False
+                return True
+        else:
+                ret_vals = []
+                for k in key:
+                        ret_vals.append(safe_clear_key(k, cache_dir=cache_dir))
+                return ret_vals
 
-def cached_func(func,key="",args=None,flush_cache=False,**kwargs):
-	md5_key = quick_md5_of_object(key)
-	unique_key = f"{func.__name__}_{md5_key}"
-	args=[] if args is None else args
-	if not quick_check(unique_key) or flush_cache:
-		result = func(*args,**kwargs,)
-		quick_save(result, out_path=unique_key)
-	ret_val = quick_load(in_path=unique_key,)
-	return ret_val
+def cached_func(func, key="", args=None, flush_cache=False, cache_dir: str | None = None, **kwargs):
+        md5_key = quick_md5_of_object(key)
+        unique_key = f"{func.__name__}_{md5_key}"
+        args = [] if args is None else args
+        if not quick_check(unique_key, cache_dir=cache_dir) or flush_cache:
+                result = func(*args, **kwargs)
+                quick_save(result, out_path=unique_key, cache_dir=cache_dir)
+        ret_val = quick_load(in_path=unique_key, cache_dir=cache_dir)
+        return ret_val
 
 def cache_path_gen(in_str):
-	if '/' in in_str:
-		in_str = in_str.rsplit("/", 1)[1]
+        if '/' in in_str:
+                in_str = in_str.rsplit("/", 1)[1]
 
-	if in_str[-6:] == '.cache':
-		in_str = in_str[:-6]
+        if in_str[-6:] == '.cache':
+                in_str = in_str[:-6]
 
-	return f"tmp/{in_str}.cache"
+        return f"tmp/{in_str}.cache"
 
 
 def str_to_int(x):
-	return int(hashlib.md5(x.encode()).hexdigest(), 16)
+        return int(hashlib.md5(x.encode()).hexdigest(), 16)
 
 def quick_md5_of_object(in_obj):
-	# print(f"  in_obj: {in_obj}")
-	if isinstance(in_obj, collections.abc.Iterable):
-		in_obj = str(in_obj)
-		# in_obj = ''.join(list(map(lambda x: str(x), in_obj)))
+        # print(f"  in_obj: {in_obj}")
+        if isinstance(in_obj, collections.abc.Iterable):
+                in_obj = str(in_obj)
+                # in_obj = ''.join(list(map(lambda x: str(x), in_obj)))
 
-	in_obj_dumps = pickle.dumps(in_obj)
-	# in_obj_dumps = json.dumps(in_obj).encode()
+        in_obj_dumps = pickle.dumps(in_obj)
+        # in_obj_dumps = json.dumps(in_obj).encode()
 
-	ret_val = hashlib.md5(in_obj_dumps).hexdigest()
-	return str(ret_val)
+        ret_val = hashlib.md5(in_obj_dumps).hexdigest()
+        return str(ret_val)
 
 def quick_hash_of_object(in_obj):
-	# print(f"  in_obj: {in_obj}")
-	if isinstance(in_obj, collections.abc.Iterable):
-		in_obj = str(in_obj)
-		# in_obj = ''.join(list(map(lambda x: str(x), in_obj)))
+        # print(f"  in_obj: {in_obj}")
+        if isinstance(in_obj, collections.abc.Iterable):
+                in_obj = str(in_obj)
+                # in_obj = ''.join(list(map(lambda x: str(x), in_obj)))
 
-	in_obj_dumps = pickle.dumps(in_obj)
-	# in_obj_dumps = json.dumps(in_obj).encode()
+        in_obj_dumps = pickle.dumps(in_obj)
+        # in_obj_dumps = json.dumps(in_obj).encode()
 
-	ret_val = hashlib.sha256(in_obj_dumps).hexdigest()
-	return f"{ret_val}"
+        ret_val = hashlib.sha256(in_obj_dumps).hexdigest()
+        return f"{ret_val}"
 
 def quick_hash_to_int(in_obj):
-	if isinstance(in_obj, collections.abc.Iterable) and not isinstance(in_obj, (str, bytes)):
-		# Use JSON for consistent serialization of iterables (e.g., dicts, lists)
-		in_obj_dumps = json.dumps(in_obj, sort_keys=True).encode()
-	else:
-		# Use pickle for other types
-		in_obj_dumps = pickle.dumps(in_obj)
-	
-	# Generate the SHA-256 hash and convert to an integer
-	ret_val = hashlib.sha256(in_obj_dumps).hexdigest()
-	print(f"  in_obj: {in_obj} -->  ret_val: {ret_val}")
-	return int(ret_val, 16)
+        if isinstance(in_obj, collections.abc.Iterable) and not isinstance(in_obj, (str, bytes)):
+                # Use JSON for consistent serialization of iterables (e.g., dicts, lists)
+                in_obj_dumps = json.dumps(in_obj, sort_keys=True).encode()
+        else:
+                # Use pickle for other types
+                in_obj_dumps = pickle.dumps(in_obj)
+        
+        # Generate the SHA-256 hash and convert to an integer
+        ret_val = hashlib.sha256(in_obj_dumps).hexdigest()
+        print(f"  in_obj: {in_obj} -->  ret_val: {ret_val}")
+        return int(ret_val, 16)
 
 quick_hash = quick_hash_of_object
 hash = quick_hash_of_object
 # quick_hash = lambda x: str(quick_hash_to_int(x))
-# hash = quick_hash	
+# hash = quick_hash     
 
 def int_hash_of_object(in_obj):
-	hash_str = quick_hash_of_object(in_obj)
-	hash_int = int(hash_str, 16) % (2**32-1)
-	return hash_int
+        hash_str = quick_hash_of_object(in_obj)
+        hash_int = int(hash_str, 16) % (2**32-1)
+        return hash_int
 
 def create_seeded_rng(**x):
-	rng_key = int_hash_of_object(x)
-	rng = np.random.default_rng(rng_key)
-	return rng
+        rng_key = int_hash_of_object(x)
+        rng = np.random.default_rng(rng_key)
+        return rng
 
 def md5_path_gen(in_str):
-	if '/' in in_str:
-		in_str = in_str.rsplit("/", 1)[1]
-	return f"tmp/{in_str}.md5"
+        if '/' in in_str:
+                in_str = in_str.rsplit("/", 1)[1]
+        return f"tmp/{in_str}.md5"
 
 
 
 
 def easy_load(in_path, default=None, default_func=None, default_func_args=None):
-	if quick_check(in_path):
-		return quick_load(in_path)
+        if quick_check(in_path):
+                return quick_load(in_path)
 
-	if default_func is not None:
-		return default_func(*default_func_args)
+        if default_func is not None:
+                return default_func(*default_func_args)
 
-	return default
-
-
-
-def quick_check(in_path, generate_path=True):
-	if generate_path:
-		in_path = quick_path_gen(in_path)
-
-	return os.path.exists(in_path)
+        return default
 
 
-def quick_path_gen(in_obj_name,clean_slashes=True,):
-	## Clean off extra slashes
-	if clean_slashes:
-		in_obj_name = in_obj_name.rsplit("/", 1)[-1]    
 
-	return f"{_config.TMP_DIR}/{in_obj_name}.cache"
+def quick_check(in_path, generate_path=True, cache_dir: str | None = None):
+        if generate_path:
+                in_path = quick_path_gen(in_path, cache_dir=cache_dir)
 
-def quick_check(in_path, generate_path=True):
-	if generate_path:
-		in_path = quick_path_gen(in_path)
-
-	return os.path.exists(in_path)
+        return os.path.exists(in_path)
 
 
-def _quick_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, ):
-	# if out_path is None and type(in_obj) == str:
-	#     out_path = in_obj
-	if isinstance(type(in_obj), str) and (not isinstance(type(out_path), str)):
-		(in_obj, out_path) = (out_path, in_obj)
-		
-	if generate_path:
-		out_path = quick_path_gen(out_path)
-	else:
-		base_dir = os.path.dirname(out_path)
-		if not os.path.exists(base_dir):
-			# os.makedirs(base_dir)
-			os.system(f"mkdir -p {base_dir}")
+def quick_path_gen(in_obj_name, cache_dir: str | None = None, clean_slashes=True,):
+        ## Clean off extra slashes
+        if clean_slashes:
+                in_obj_name = in_obj_name.rsplit("/", 1)[-1]
 
-	# if store_in_tmp:
-	#     split = out_path.split('/', 0)
-	#     if split is not None and len(split) > 1:
-	#         split = split[0]
-	#         if 'tmp' not in split:
-	#             out_path = f'/tmp/{out_path}'
+        base = cache_dir if cache_dir is not None else _config.TMP_DIR
+        return f"{base}/{in_obj_name}.cache"
 
 
-	try:
-		with open(out_path, 'wb') as f:
-			pickle.dump(in_obj, f)
-	except:
-		os.system(f"mkdir -p {out_path.rsplit('/', 1)[0]}")
-		with open(out_path, 'wb') as f:
-			pickle.dump(in_obj, f)
-	print(f"  Quick saved to {out_path}!")
+def _quick_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, cache_dir: str | None = None):
+        # if out_path is None and type(in_obj) == str:
+        #     out_path = in_obj
+        if isinstance(type(in_obj), str) and (not isinstance(type(out_path), str)):
+                (in_obj, out_path) = (out_path, in_obj)
+                
+        if generate_path:
+                out_path = quick_path_gen(out_path, cache_dir=cache_dir)
+        else:
+                base_dir = os.path.dirname(out_path)
+                if not os.path.exists(base_dir):
+                        # os.makedirs(base_dir)
+                        os.system(f"mkdir -p {base_dir}")
 
-	# print(f"Quick saved to \"{out_path}\"! (type(in_obj): {type(in_obj)})")
-	return out_path
+        # if store_in_tmp:
+        #     split = out_path.split('/', 0)
+        #     if split is not None and len(split) > 1:
+        #         split = split[0]
+        #         if 'tmp' not in split:
+        #             out_path = f'/tmp/{out_path}'
 
-def quick_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, ):
-	try:
-		assert(isinstance(out_path, str))
-		_quick_save(in_obj=in_obj, out_path=out_path, generate_path=generate_path, store_in_tmp=store_in_tmp,)
-	except:
-		print(f"  WARNING:  cache.py  quick_save() exception!  out_path is not a string.", flush=True,)
-		_quick_save(in_obj=out_path, out_path=in_obj, generate_path=generate_path, store_in_tmp=store_in_tmp,)
+
+        try:
+                with open(out_path, 'wb') as f:
+                        pickle.dump(in_obj, f)
+        except:
+                os.system(f"mkdir -p {out_path.rsplit('/', 1)[0]}")
+                with open(out_path, 'wb') as f:
+                        pickle.dump(in_obj, f)
+        print(f"  Quick saved to {out_path}!")
+
+        # print(f"Quick saved to \"{out_path}\"! (type(in_obj): {type(in_obj)})")
+        return out_path
+
+def quick_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, cache_dir: str | None = None):
+        try:
+                assert(isinstance(out_path, str))
+                _quick_save(in_obj=in_obj, out_path=out_path, generate_path=generate_path, store_in_tmp=store_in_tmp, cache_dir=cache_dir)
+        except Exception:
+                print(f"  WARNING:  cache.py  quick_save() exception!  out_path is not a string.", flush=True,)
+                _quick_save(in_obj=out_path, out_path=in_obj, generate_path=generate_path, store_in_tmp=store_in_tmp, cache_dir=cache_dir)
 
 
 
 def safe_write_to_file(in_obj, out_path, style='json', write_mode='w',):
 
-	# with open(oppa, 'w') as f:
-	# 	json.dump(make_json_dumpable(results[task_name]), f)
+        # with open(oppa, 'w') as f:
+        #       json.dump(make_json_dumpable(results[task_name]), f)
 
-	in_obj_hash = quick_hash_of_object(in_obj)
+        in_obj_hash = quick_hash_of_object(in_obj)
 
-	while True:
-		if style == 'json':
+        while True:
+                if style == 'json':
 
-			try:
-				with open(out_path, write_mode) as f:
-					json.dump(in_obj, f)
-				time.sleep(1)
+                        try:
+                                with open(out_path, write_mode) as f:
+                                        json.dump(in_obj, f)
+                                time.sleep(1)
 
-				# written_hash = quick_hash_of_object(json.load(open(out_path, 'r')))
-			except Exception as write_e:
-				print(f"  write_e: {write_e}")
-				traceback.print_exc()
-				time.sleep(5)
+                                # written_hash = quick_hash_of_object(json.load(open(out_path, 'r')))
+                        except Exception as write_e:
+                                print(f"  write_e: {write_e}")
+                                traceback.print_exc()
+                                time.sleep(5)
 
-			# if (in_obj_hash == written_hash):
-			# 	break
-			break
-			print(f"  WARNING:  cache.py  safe_write_to_file()  Hash mismatch!  Retrying...", flush=True,)
-			time.sleep(5)
-			continue
+                        # if (in_obj_hash == written_hash):
+                        #       break
+                        break
+                        print(f"  WARNING:  cache.py  safe_write_to_file()  Hash mismatch!  Retrying...", flush=True,)
+                        time.sleep(5)
+                        continue
 
-		elif style == 'pickle':
-			with open(out_path, write_mode) as f:
-				pickle.dump(in_obj, f)
-			written_hash = quick_hash_of_object(pickle.load(open(out_path, 'rb')))
-			if (in_obj_hash == written_hash):
-				break
-			print(f"  WARNING:  cache.py  safe_write_to_file()  Hash mismatch!  Retrying...", flush=True,)
-			time.sleep(5)
-			continue
-			
-		else:
-			raise Exception(f"  WARNING:  cache.py  safe_write_to_file()  Unknown style: {style}", flush=True,)
+                elif style == 'pickle':
+                        with open(out_path, write_mode) as f:
+                                pickle.dump(in_obj, f)
+                        written_hash = quick_hash_of_object(pickle.load(open(out_path, 'rb')))
+                        if (in_obj_hash == written_hash):
+                                break
+                        print(f"  WARNING:  cache.py  safe_write_to_file()  Hash mismatch!  Retrying...", flush=True,)
+                        time.sleep(5)
+                        continue
+                        
+                else:
+                        raise Exception(f"  WARNING:  cache.py  safe_write_to_file()  Unknown style: {style}", flush=True,)
 
-	print(f"  Safely wrote to \"{out_path}\"!", flush=True,)
-
-
-
-def quick_safe_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, ):
-
-	in_obj_hash = quick_hash_of_object(in_obj)
-
-	while True:
-		try:
-			quick_save(in_obj=in_obj, out_path=out_path, generate_path=generate_path, store_in_tmp=store_in_tmp,)
-
-			loaded = quick_load(out_path)
-			loaded_hash = quick_hash_of_object(loaded)
-
-			if in_obj_hash == loaded_hash:
-				break
-
-			raise Exception(f"  WARNING:  cache.py  quick_safe_save()  Hash mismatch!  Retrying...", flush=True,)
-
-		except Exception as e:
-			print(f"  WARNING:  cache.py  save_safe() exception!  Retrying... e: {e}", flush=True,)
-			time.sleep(5)
+        print(f"  Safely wrote to \"{out_path}\"!", flush=True,)
 
 
 
-def async_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, ):
-	thread = threading.Thread(target=quick_save, args=(in_obj, out_path, generate_path, store_in_tmp,))
-	try:
-		thread.start()
-	except Exception as e:
-		print(f"  WARNING:  cache.py  async_save() exception!  Running synchronously... e: {e}")
-		quick_save(in_obj, out_path, generate_path, store_in_tmp,)
+def quick_safe_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, cache_dir: str | None = None):
 
-	return thread
+        in_obj_hash = quick_hash_of_object(in_obj)
 
-def quick_load(in_path, generate_path=True, default_value=None, silent=0,):
-	if generate_path:
-		in_path = quick_path_gen(in_path)
+        while True:
+                try:
+                        quick_save(in_obj=in_obj, out_path=out_path, generate_path=generate_path, store_in_tmp=store_in_tmp, cache_dir=cache_dir)
 
-	if os.path.exists(in_path):
-		# if not silent:
-		# 	print(f"  cache.quick_load():  is loading from \"{in_path}\"...", flush=True,)
-		try:
-			with open(in_path, 'rb') as f:
-				return pickle.load(f)
-		finally:
-			pass
-			# if not silent:
-			# 	print(f"  cache.quick_load():  Finished loading from \"{in_path}\"!", flush=True,)
-	else:
-		raise Exception(f"quick_load({in_path}) failed: File does not exist.")
+                        loaded = quick_load(out_path, cache_dir=cache_dir)
+                        loaded_hash = quick_hash_of_object(loaded)
+
+                        if in_obj_hash == loaded_hash:
+                                break
+
+                        raise Exception(f"  WARNING:  cache.py  quick_safe_save()  Hash mismatch!  Retrying...", flush=True,)
+
+                except Exception as e:
+                        print(f"  WARNING:  cache.py  save_safe() exception!  Retrying... e: {e}", flush=True,)
+                        time.sleep(5)
 
 
-########
 
-  
+def async_save(in_obj, out_path=None, generate_path=True, store_in_tmp=True, cache_dir: str | None = None):
+        thread = threading.Thread(target=quick_save, args=(in_obj, out_path, generate_path, store_in_tmp, cache_dir))
+        try:
+                thread.start()
+        except Exception as e:
+                print(f"  WARNING:  cache.py  async_save() exception!  Running synchronously... e: {e}")
+                quick_save(in_obj, out_path, generate_path, store_in_tmp, cache_dir)
+
+        return thread
+
+def quick_load(in_path, generate_path=True, default_value=None, silent=0, cache_dir: str | None = None):
+        if generate_path:
+                in_path = quick_path_gen(in_path, cache_dir=cache_dir)
+
+        if os.path.exists(in_path):
+                # if not silent:
+                #       print(f"  cache.quick_load():  is loading from \"{in_path}\"...", flush=True,)
+                try:
+                        with open(in_path, 'rb') as f:
+                                return pickle.load(f)
+                finally:
+                        pass
+                        # if not silent:
+                        #       print(f"  cache.quick_load():  Finished loading from \"{in_path}\"!", flush=True,)
+        else:
+                raise Exception(f"quick_load({in_path}) failed: File does not exist.")


### PR DESCRIPTION
## Summary
- add `set_TMP_DIR` helper to override cache location
- update cache helpers to accept optional `cache_dir`
- plumb `cache_dir` through API and `VLLMClient`
- document `cache_dir` argument in README

## Testing
- `python -m py_compile quick_vllm/api.py quick_vllm/vllm_client.py quick_vllm/cache.py quick_vllm/_config.py`
- `pytest -q` *(fails: command not found)*