### PR TITLE
Add async wrapper and remove optional imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ responses = send(
 print(responses)
 ```
 
+Need asynchronous results?  Use `async_=True` or the
+convenience wrapper `send_async`:
+
+```python
+handle = send(msgs, async_=True)
+responses = handle.get()
+# Equivalent
+responses2 = send_async(msgs).get()
+```
+
 ### 2 • Object-oriented client
 
 Need to hit multiple vLLM back-ends in the same programme?  Use the

--- a/quick_vllm/__init__.py
+++ b/quick_vllm/__init__.py
@@ -15,6 +15,7 @@ Object-oriented client
 
 from .api import (
     send,
+    send_async,
     send_message,
     send_message_no_cache,
     encode_image,
@@ -27,6 +28,7 @@ from .vllm_client import VLLMClient
 __all__ = [
     # functional API
     "send",
+    "send_async",
     "send_message",
     "send_message_no_cache",
     "encode_image",

--- a/quick_vllm/api.py
+++ b/quick_vllm/api.py
@@ -338,10 +338,25 @@ pass
 
 
 
+class _AsyncSendResult:
+    """Handle for asynchronous :func:`send` calls."""
+
+    def __init__(self, async_result, pool):
+        self._async_result = async_result
+        self._pool = pool
+
+    def get(self, *args, **kwargs):
+        result = self._async_result.get(*args, **kwargs)
+        self._pool.join()
+        return result
+
+
 def send(
     msgs,
     max_pool_size=mp.cpu_count(),
-    cache_dir=None, # Added cache_dir
+    cache_dir=None,  # Added cache_dir
+    *,
+    async_=False,
     **kwargs,
 ):
     if isinstance(msgs, str):
@@ -350,16 +365,29 @@ def send(
     max_pool_size = min(max_pool_size, len(msgs))
     pool = mp.Pool(processes=max_pool_size)
 
-    # pool = mp.pool.ThreadPool(processes=max_pool_size)
-
     # Include cache_dir in the kwargs for each message
     current_call_kwargs = {**kwargs, "cache_dir": cache_dir}
     msgs_with_kwargs = [dict(msg=msg, kwargs=current_call_kwargs) for msg in msgs]
-    responses = pool.map(_batch_send_message_wrapper, msgs_with_kwargs)
 
+    if async_:
+        async_result = pool.map_async(_batch_send_message_wrapper, msgs_with_kwargs)
+        pool.close()
+        return _AsyncSendResult(async_result, pool)
+
+    responses = pool.map(_batch_send_message_wrapper, msgs_with_kwargs)
     pool.close()
     pool.join()
-
     return responses
 pass
+
+
+def send_async(msgs, max_pool_size=mp.cpu_count(), cache_dir=None, **kwargs):
+    """Convenience wrapper around :func:`send` with ``async_=True``."""
+    return send(
+        msgs,
+        max_pool_size=max_pool_size,
+        cache_dir=cache_dir,
+        async_=True,
+        **kwargs,
+    )
 

--- a/quick_vllm/tests/test_cache.py
+++ b/quick_vllm/tests/test_cache.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 import pickle
+import multiprocessing as mp
 from unittest.mock import patch, MagicMock
 
 from quick_vllm import cache
@@ -203,6 +204,23 @@ class TestCacheFunctionality(unittest.TestCase):
         
         # Assert that the mocked API (client.chat.completions.create) was NOT called this time
         mock_client_instance.chat.completions.create.assert_not_called()
+
+    def test_async_send_returns_same_result(self):
+        messages = ["a", "b", "c"]
+
+        def fake_wrapper(d):
+            return f"resp_{d['msg']}"
+
+        with patch("quick_vllm.api._batch_send_message_wrapper", side_effect=fake_wrapper), \
+             patch("multiprocessing.Pool", mp.pool.ThreadPool):
+            sync_result = api.send(messages)
+            handle = api.send(messages, async_=True)
+            async_result = handle.get()
+            async_result_2 = api.send_async(messages).get()
+
+        self.assertEqual(async_result, sync_result)
+        self.assertEqual(async_result_2, sync_result)
+        self.assertEqual(async_result, [f"resp_{m}" for m in messages])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- provide `send_async` convenience wrapper for asynchronous sends
- expose `send_async` via `quick_vllm.__init__`
- add `send_async` method to `VLLMClient`
- document asynchronous usage in README
- simplify tests to cover both async approaches
- remove optional fallbacks for `openai` and `numpy`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*