### PR TITLE
Add per-item async handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,13 @@ convenience wrapper `send_async`:
 
 ```python
 handle = send(msgs, async_=True)
-responses = handle.get()
-# Equivalent
-responses2 = send_async(msgs).get()
+
+# Fetch them all at once
+all_responses = handle.get()
+
+# Or grab each one as soon as it's ready
+for resp in send_async(msgs):
+    print(resp.get())
 ```
 
 ### 2 • Object-oriented client

--- a/quick_vllm/tests/test_cache.py
+++ b/quick_vllm/tests/test_cache.py
@@ -222,6 +222,19 @@ class TestCacheFunctionality(unittest.TestCase):
         self.assertEqual(async_result_2, sync_result)
         self.assertEqual(async_result, [f"resp_{m}" for m in messages])
 
+    def test_async_send_individual_get(self):
+        messages = ["a", "b", "c"]
+
+        def fake_wrapper(d):
+            return f"resp_{d['msg']}"
+
+        with patch("quick_vllm.api._batch_send_message_wrapper", side_effect=fake_wrapper), \
+             patch("multiprocessing.Pool", mp.pool.ThreadPool):
+            handle = api.send_async(messages)
+            results = [item.get() for item in handle]
+
+        self.assertEqual(results, [f"resp_{m}" for m in messages])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/quick_vllm/vllm_client.py
+++ b/quick_vllm/vllm_client.py
@@ -182,9 +182,11 @@ class VLLMClient:
         args = [{**common, "msg": m} for m in msgs]
 
         if async_:
-            async_result = pool.map_async(_worker_send_wrapper, args)
+            async_results = [
+                pool.apply_async(_worker_send_wrapper, (a,)) for a in args
+            ]
             pool.close()
-            return _AsyncSendResult(async_result, pool)
+            return _AsyncSendResult(async_results, pool)
 
         try:
             return pool.map(_worker_send_wrapper, args)


### PR DESCRIPTION
## Summary
- allow grabbing async results individually
- update docs for new async iteration
- adjust thread pool usage for async sends
- add a test for per-item async fetching

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*