### PR TITLE
Support streaming with async

### DIFF
--- a/quick_vllm/api.py
+++ b/quick_vllm/api.py
@@ -1,5 +1,6 @@
 from openai import OpenAI
 import multiprocessing as mp
+from multiprocessing import pool as mp_pool
 import os
 import traceback
 import base64
@@ -396,7 +397,13 @@ def send(
         msgs = [msgs]
 
     max_pool_size = min(max_pool_size, len(msgs))
-    pool = mp.Pool(processes=max_pool_size)
+
+    # Use threads when asynchronous streaming is requested so that
+    # tokens printed by worker tasks appear in the main console.
+    if async_ and stream_print:
+        pool = mp_pool.ThreadPool(processes=max_pool_size)
+    else:
+        pool = mp.Pool(processes=max_pool_size)
 
     # Include cache_dir in the kwargs for each message
     current_call_kwargs = {**kwargs, "cache_dir": cache_dir}

--- a/quick_vllm/vllm_client.py
+++ b/quick_vllm/vllm_client.py
@@ -14,6 +14,7 @@ import base64
 import copy
 import datetime as _dt
 import multiprocessing as mp
+from multiprocessing import pool as mp_pool
 import os
 import time
 from typing import Any, Iterable
@@ -175,7 +176,13 @@ class VLLMClient:
             msgs = [msgs]
 
         max_pool_size = min(max_pool_size or mp.cpu_count(), len(msgs))
-        pool = mp.Pool(processes=max_pool_size)
+
+        # Use threads when asynchronous streaming is requested so that
+        # tokens printed by worker tasks appear in the main console.
+        if async_ and stream_print:
+            pool = mp_pool.ThreadPool(processes=max_pool_size)
+        else:
+            pool = mp.Pool(processes=max_pool_size)
 
         # shared data passed to every worker (must be pickleable)
         common = {


### PR DESCRIPTION
## Summary
- use `ThreadPool` when streaming with async calls
- allow tokens to stream in the main process while tasks run

## Testing
- `pytest -q`