### PR TITLE
Add macOS fork start method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Welcome to **quick VLLM**, a slim Python wrapper that makes talking to a
 pip install --upgrade vllm
 pip install git+https://github.com/SamBlouir/quick_vllm.git
 ````
+### macOS
+On macOS the default multiprocessing start method is `spawn`. `quick_vllm` now automatically switches to `fork` so that pooling works correctly.
+
 
 ---
 

--- a/quick_vllm/__init__.py
+++ b/quick_vllm/__init__.py
@@ -12,6 +12,18 @@ Functional helpers
 Object-oriented client
     VLLMClient                – from :pymod:`quick_vllm.vllm_client`
 """
+import sys
+
+# ---------------------------------------------------------------------------
+# macOS uses the 'spawn' start method by default which breaks pooling in this
+# package. Switch to 'fork' if running on a Mac.
+if sys.platform == "darwin":
+    import multiprocessing as mp
+    try:  # set_start_method() can only be called once per session
+        mp.set_start_method("fork")
+    except RuntimeError:
+        pass
+
 
 from .api import (
     send,


### PR DESCRIPTION
## Summary
- set the multiprocessing start method to `fork` on macOS
- document the behaviour in the README

## Testing
- `pytest -q`